### PR TITLE
Markups planes export

### DIFF
--- a/OpenAnatomyExport/OpenAnatomyExport.py
+++ b/OpenAnatomyExport/OpenAnatomyExport.py
@@ -351,11 +351,11 @@ class OpenAnatomyExportLogic(ScriptedLoadableModuleLogic):
       for itemIdIndex in range(childIds.GetNumberOfIds()):
         shItemId = childIds.GetId(itemIdIndex)
         dataNode = shNode.GetItemDataNode(shItemId)
-        if (
-          dataNode and (
-            dataNode.IsA("vtkMRMLModelNode") or dataNode.IsA("vtkMRMLMarkupsPlaneNode")
-            )
-          ):
+        dataNotNone = dataNode is not None
+        isModel = dataNotNone and dataNode.IsA("vtkMRMLModelNode")
+        isMarkupsPlane = dataNotNone and dataNode.IsA("vtkMRMLMarkupsPlaneNode")
+        dataIsValid = (isModel or isMarkupsPlane)
+        if dataIsValid:
           if dataNode.IsA("vtkMRMLModelNode"):
             inputModelNode = dataNode
           else:
@@ -526,8 +526,7 @@ class OpenAnatomyExportLogic(ScriptedLoadableModuleLogic):
     # Copy props from markups to model
     planeMarkupDisplayNode = planeMarkup.GetDisplayNode()
     planeModelDisplayNode = planeModel.GetDisplayNode()
-    planeColor = planeMarkupDisplayNode.GetSelectedColor()
-    planeModelDisplayNode.SetColor(planeColor)
+    planeModelDisplayNode.SetColor(planeMarkupDisplayNode.GetSelectedColor())
     planeOpacity = planeMarkupDisplayNode.GetFillOpacity()
     planeModelDisplayNode.SetOpacity(planeOpacity)
     planeModel.SetName(planeMarkup.GetName())

--- a/OpenAnatomyExport/OpenAnatomyExport.py
+++ b/OpenAnatomyExport/OpenAnatomyExport.py
@@ -408,10 +408,12 @@ class OpenAnatomyExportLogic(ScriptedLoadableModuleLogic):
       self._temporaryExportNodes.append(self._decimationParameterNode)
 
     # Quadric decimation
-    if self.reductionFactor == 0.0:
+    if (self.reductionFactor == 0.0) or (inputModelNode.GetPolyData().GetNumberOfPoints() < 50):
+      # Models with very small number of points are not decimated, as the memory saving is
+      # negligible and the models may become severely distorted.
       outputModelNode.CopyContent(inputModelNode)
     else:
-      
+
       # Temporary workaround (part 1/2):
       # VTK 9.0 OBJ writer creates invalid OBJ file if there are triangle
       # strips and normals but no texture coords.


### PR DESCRIPTION
I did not find a way to not duplicate some code on the `addModelsToRenderer` function because its recursive and I didn't wanted to analyze it too much (but I can do it if required). 

It works

![model](https://user-images.githubusercontent.com/19158307/209356763-91de6efb-5e31-4b31-8c28-7b5bcb07a828.png)
